### PR TITLE
Bug fix for background is not showing in Firefox because opacity was not applied

### DIFF
--- a/js/dragquestion.js
+++ b/js/dragquestion.js
@@ -750,7 +750,12 @@ H5P.DragQuestion = (function ($) {
       // Set both color and gradient.
       C.setOpacity($element, 'backgroundColor', opacity);
       C.setOpacity($element, 'backgroundImage', opacity);
-      $element.css('opacity', opacity);
+      if (!opacity) {
+        $element.css({
+          "background-color": "rgba(245, 245, 245, 0)",
+          "background-image": "none"
+        });
+      }
       return;
     }
 

--- a/js/dragquestion.js
+++ b/js/dragquestion.js
@@ -750,6 +750,7 @@ H5P.DragQuestion = (function ($) {
       // Set both color and gradient.
       C.setOpacity($element, 'backgroundColor', opacity);
       C.setOpacity($element, 'backgroundImage', opacity);
+      $element.css('opacity', opacity);
       return;
     }
 


### PR DESCRIPTION

Fix for Firefox when background image does not show.
Append inline css for opacity to ui-droppable element.