### PR TITLE
Issue #9 Added 'Incorrect feedback text' support

### DIFF
--- a/js/dragquestion.js
+++ b/js/dragquestion.js
@@ -669,14 +669,19 @@ H5P.DragQuestion = (function ($) {
   };
 
   /**
-   * Shows the score to the user when the score button i pressed.
+   * Shows the score to the user when the score button is pressed.
+   * Modified by SUPRIYA RAJGOPAL on 1Sep16 to show (in)correct feedback depending on the points scored
    */
   C.prototype.showScore = function () {
     var maxScore = this.calculateMaxScore();
     if (this.options.behaviour.singlePoint) {
       maxScore = 1;
     }
-    var scoreText = this.options.feedback.replace('@score', this.points).replace('@total', maxScore);
+	var scoreText;
+	if(this.points == maxScore)
+		scoreText = this.options.feedback.replace('@score', this.points).replace('@total', maxScore);
+	else
+		scoreText = this.options.incorrect_feedback.replace('@score', this.points).replace('@total', maxScore);
     this.setFeedback(scoreText, this.points, maxScore);
   };
 

--- a/semantics.json
+++ b/semantics.json
@@ -22,12 +22,20 @@
     "common": true
   },
   {
-    "label": "Feedback text",
+    "label": "Correct feedback text",
     "name": "feedback",
     "type": "text",
     "default": "You got @score of @total points",
-    "description": "Feedback text, variables available: @score and @total. Example: 'You got @score of @total points.'",
-    "common": true
+    "description": "Feedback text when correct answer is given, variables available: @score and @total. Example: 'You got @score of @total points.'",
+    "common": false
+  },
+  {
+    "label": "Incorrect feedback text",
+    "name": "incorrect_feedback",
+    "type": "text",
+    "default": "Sorry, this answer is incorrect",
+    "description": "Feedback text when incorrect answer is given, variables available: @score and @total.'",
+    "common": false
   },
   {
     "name": "question",


### PR DESCRIPTION
- 'Incorrect feedback text' field is added and showScore() is modified to show (in)correct feedback per drag-and-drop question.
- Also made the 'common' setting as 'false' and changed the label for 'Feedback' field so that it appears on every drag-and-drop question instead of for the whole question set