### PR TITLE
Proposal for extra color & opacity settings

### DIFF
--- a/css/dragquestion.css
+++ b/css/dragquestion.css
@@ -83,9 +83,7 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
    background: #edd6e9;
  }
 .h5p-dragquestion .h5p-draggable.h5p-dropped {
-  color: #1a4473;
   border: 0.1em solid #a9c3d0;
-  background: #cee0f4;
 }
 .h5p-dragquestion .h5p-draggable > img {
   pointer-events: none;
@@ -120,19 +118,17 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
   line-height: 1em;
 }
 
-.h5p-dragquestion .h5p-dropped.h5p-correct, .h5p-dragquestion .h5p-dropzone.h5p-correct-answer {
-  color: #255c41;
+.h5p-dragquestion .h5p-dropped.h5p-correct,
+.h5p-dragquestion .h5p-dropzone.h5p-correct-answer {
   border: 0.1em solid #9dd8bb;
   box-shadow: none;
-  background: #9dd8bb;
 }
 
 .h5p-dragquestion .h5p-dropped.h5p-wrong {
   border: 0.1em solid #f7d0d0;
-  color: #b71c1c;
-  background: #f7d0d0;
 }
-.h5p-dragquestion .h5p-dropped.h5p-wrong, .h5p-dragquestion .h5p-dropped.h5p-correct {
+.h5p-dragquestion .h5p-dropped.h5p-wrong,
+.h5p-dragquestion .h5p-dropped.h5p-correct {
   text-align: left;
 }
 
@@ -161,10 +157,12 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
 }
 .h5p-dragquestion .h5p-dropped.h5p-correct:after {
   content: "\f00c";
+  color: green;
 }
 
 .h5p-dragquestion .h5p-dropped.h5p-wrong:after {
   content: "\f00d";
+  color: red;
 }
 
 .h5p-dragquestion .h5p-dropzone {
@@ -184,12 +182,6 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
   border-radius: 0 0em 0.25em 0.25em;
 }
 
-.h5p-dragquestion .h5p-dq-highlight-dz .h5p-dropzone > .h5p-inner.h5p-active,
-.h5p-dragquestion .h5p-dq-highlight-dz-always .h5p-dropzone > .h5p-inner {
-  padding: 0;
-  border: 2px dashed #666;
-}
-
 .h5p-dragquestion .h5p-dropzone > .h5p-inner.h5p-over {
   background: #edd6e9;
 }
@@ -199,12 +191,12 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
   padding-left: 0.5em;
   right: 0;
   left: 0;
-  bottom: 100%;
   white-space: nowrap;
   border-radius: 0.25em 0.25em 0 0;
   position: absolute;
 
   background: #ddd;
+  top: -1.50em;
 }
 
 .h5p-dragquestion .h5p-dropzone-answer {
@@ -223,7 +215,7 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
   position: absolute;
   right: 0.15em;
   bottom: 0;
-  font-size: 0.8em;
+  font-size: 1em;
 }
 
 .h5p-dragquestion .h5p-question-feedback .joubel-tip-container {
@@ -239,4 +231,11 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
 .h5p-dragquestion.h5p-fullscreen > .h5p-question-introduction {
   margin-left: 1em;
   margin-right: 1em;
+}
+/* The border color is now done in the edit interface */
+.h5p-dragquestion .h5p-dq-highlight-dz .h5p-dropzone,
+.h5p-dragquestion .h5p-dq-highlight-dz-always .h5p-dropzone {
+  padding: 0;
+  border-style: dashed!important;
+  border-width: 0.15em;
 }

--- a/js/dragquestion.js
+++ b/js/dragquestion.js
@@ -54,7 +54,9 @@ H5P.DragQuestion = (function ($) {
     this.blankIsCorrect = true;
 
     this.backgroundOpacity = (this.options.backgroundOpacity === undefined || this.options.backgroundOpacity.trim() === '') ? undefined : this.options.backgroundOpacity;
-
+    this.overrideBorderColor = (this.options.overrideBorderColor === "rgba(255, 255, 255, 0)") ? undefined : this.options.overrideBorderColor;
+    this.backgroundColor = (this.options.question.settings.backgroundColor === "rgba(255, 255, 255, 0)") ? undefined : this.options.question.settings.backgroundColor;
+    this.backgroundOpacityDropZones = this.options.backgroundOpacityDropZones;
     // List of drop zones that has no elements, i.e. not used for the task
     var dropZonesWithoutElements = [];
 
@@ -71,6 +73,12 @@ H5P.DragQuestion = (function ($) {
           this.correctDZs[correctElement] = [];
         }
         this.correctDZs[correctElement].push(i);
+      }
+      if (this.overrideBorderColor !== undefined) {
+        task.dropZones[i].bordercolor = this.overrideBorderColor;
+      }
+      if (this.backgroundOpacityDropZones !== undefined) {
+        task.dropZones[i].backgroundOpacity = this.backgroundOpacityDropZones;
       }
     }
 
@@ -360,6 +368,8 @@ H5P.DragQuestion = (function ($) {
     this.$container = $('<div class="h5p-inner"></div>');
     if (this.options.question.settings.background !== undefined) {
       this.$container.css('backgroundImage', 'url("' + H5P.getPath(this.options.question.settings.background.path, this.id) + '")');
+    } else if (this.backgroundColor !== undefined) {
+      this.$container.css('background-color', this.backgroundColor);
     }
 
     var task = this.options.question.task;
@@ -1374,6 +1384,7 @@ H5P.DragQuestion = (function ($) {
     self.single = dropZone.single;
     self.autoAlignEnabled = dropZone.autoAlign;
     self.alignables = [];
+    self.dropzonebordercolor = dropZone.bordercolor;
   }
 
   /**
@@ -1390,7 +1401,7 @@ H5P.DragQuestion = (function ($) {
     var html = '<div class="h5p-inner"></div>';
     var extraClass = '';
     if (self.showLabel) {
-      html = '<div class="h5p-label">' + self.label + '</div>' + html;
+      html = '<div class="h5p-label" style="color:' + self.dropzonebordercolor + ';">' + self.label + '</div>' + html;
       extraClass = ' h5p-has-label';
     }
 
@@ -1401,7 +1412,8 @@ H5P.DragQuestion = (function ($) {
         left: self.x + '%',
         top: self.y + '%',
         width: self.width + 'em',
-        height: self.height + 'em'
+        height: self.height + 'em',
+        "border-color": self.dropzonebordercolor
       },
       html: html
     })
@@ -1463,7 +1475,7 @@ H5P.DragQuestion = (function ($) {
 
     // Add tip after setOpacity(), so this does not get background opacity:
     if (self.tip !== undefined && self.tip.trim().length) {
-      self.$dropZone.append(H5P.JoubelUI.createTip(self.tip));
+      self.$dropZone.append(H5P.JoubelUI.createTip(self.tip).css('color', self.dropzonebordercolor));
     }
 
     if (self.autoAlignEnabled) {

--- a/language/en.json
+++ b/language/en.json
@@ -2,119 +2,122 @@
   "semantics": [
     {
       "englishLabel": "Check answer button",
-      "label": "Bouton \"Vérifier\"",
+      "label": "Check answer button",
       "englishDefault": "Check",
-      "default": "Vérifier"
+      "default": "Check"
     },
     {
       "englishLabel": "Retry button",
-      "label": "Bouton \"Recommencer\"",
+      "label": "Retry button",
       "englishDefault": "Retry",
-      "default": "Recommencer"
+      "default": "Retry"
     },
     {
       "englishLabel": "Correct solution label text",
-      "label": "Bouton \"Voir la correction\"",
+      "label": "Correct solution label text",
       "englishDefault": "Show solution",
-      "default": "Voir la correction"
+      "default": "Show solution"
     },
     {
       "englishLabel": "Feedback text",
-      "label": "Appréciation finale",
+      "label": "Feedback text",
       "englishDefault": "You got @score of @total points",
-      "default": "Vous avez obtenu @score point(s) sur @total",
+      "default": "You got @score of @total points",
       "englishDescription": "Feedback text, variables available: @score and @total. Example: 'You got @score of @total points.'",
-      "description": "Texte du feedback final. Les variables disponibles sont : @score et @total. (Exemple: 'Tu as @score sur @total points.)'"
+      "description": "Feedback text, variables available: @score and @total. Example: 'You got @score of @total points.'"
     },
     {
       "englishLabel": "Score explanation text",
-      "label": "Texte d'explication du score",
+      "label": "Score explanation text",
       "englishDefault": "Correct answers give +1 point. Incorrect answers give -1 point. The lowest possible score is 0.",
-      "default": "Les réponses correctes donnent droit à +1 point. Les réponses incorrectes à -1 point. Le score le plus bas possible est 0."
+      "default": "Correct answers give +1 point. Incorrect answers give -1 point. The lowest possible score is 0."
     },
     {
       "fields": [
         {
           "englishLabel": "Settings",
-          "label": "Réglages",
+          "label": "Settings",
           "fields": [
             {
               "englishLabel": "The title of this question",
-              "label": "Titre de cette question",
+              "label": "The title of this question",
               "englishDefault": "Drag and Drop",
-              "default": "Glisser-déposer",
+              "default": "Drag and Drop",
               "englishDescription": "Used in summaries, statistics etc.",
-              "description": "Utilisé dans les résumés, statistiques, etc."
+              "description": "Used in summaries, statistics etc."
             },
             {
               "englishLabel": "Background image",
-              "label": "Image d'arrière-plan",
+              "label": "Background image",
               "englishDescription": "Optional. Select an image to use as background for your drag and drop task.",
-              "description": "Sélectionnez une image d'arrière-plan pour votre activité (facultatif)."
+              "description": "Optional. Select an image to use as background for your drag and drop task."
             },
             {
               "englishLabel": "Task size",
-              "label": "Taille de la zone de l'activité",
+              "label": "Task size",
               "englishDescription": "Specify how large (in px) the play area should be.",
-              "description": "Spécifiez la hauteur et la largeur (en pixels) de la zone de l'activité."
+              "description": "Specify how large (in px) the play area should be."
             },
             {
               "englishLabel": "Drop Zone Highlighting",
-              "label": "Mise en évidence de la zone de dépôt",
+              "label": "Drop Zone Highlighting",
               "englishDescription": "Choose when to highlight drop zones.",
-              "default": "dragging",
-              "description": "Choisissez quand mettre en évidence la zone de dépôt.",
+              "description": "Choose when to highlight drop zones.",
               "options": [
                 {
                   "englishLabel": "When dragging",
-                  "label": "Lors du glisser-déposer"
+                  "label": "When dragging"
                 },
                 {
                   "englishLabel": "Always",
-                  "label": "Toujours"
+                  "label": "Always"
                 },
                 {
                   "englishLabel": "Never",
-                  "label": "Jamais"
+                  "label": "Never"
                 }
               ]
             },
             {
               "englishLabel": "Spacing for Auto-Align (in px)",
-              "label": "Marge pour l'alignement automatique (en pixels)"
+              "label": "Spacing for Auto-Align (in px)"
             },
             {
               "englishLabel": "Task Background color",
-              "label": "Couleur de fond de la zone de l'activité",
+              "label": "Task Background color",
               "englishDescription": "The color of the task background (if no image)",
-              "description": "La couleur de fond de l'activité (s'il n'y a pas d'image de fond)"
+              "description": "The color of the task background (if no image)",
+              "englishDefault": "#fff",
+              "default": "#fff"
             },
             {
               "englishLabel": "Border color for drop zones",
-              "label": "Couleur de la bordure des zones de dépôt",
+              "label": "Border color for drop zones",
               "englishDescription": "If this color is set, it will override the color of the individual dropzones borders",
-              "description": "Si vous choisissez une couleur, cette couleur écrasera le choix individuel de couleur des zones de dépôt."
+              "description": "If this color is set, it will override the color of the individual dropzones borders",
+              "englishDefault": "rgba(255, 255, 255, 0)",
+              "default": "rgba(255, 255, 255, 0)"
             }
           ]
         },
         {
           "englishLabel": "Task",
-          "label": "Éléments de l'activité",
+          "label": "Task",
           "englishDescription": "Start by placing your drop zones.<br/>Next, place your droppable elements and check off the appropriate drop zones.<br/>Last, edit your drop zone again and check off the correct answers.",
-          "description": "Commencez par créer vos zones de dépôt.<br/>Ensuite, créez les étiquettes à glisser en cochant la/les zone(s) où elles pourront être glissées.<br/>Enfin, éditez de nouveau vos zones de dépôt et cochez les étiquettes qui devront y être correctement placées.",
+          "description": "Start by placing your drop zones.<br/>Next, place your droppable elements and check off the appropriate drop zones.<br/>Last, edit your drop zone again and check off the correct answers.",
           "fields": [
             {
               "englishLabel": "Elements",
-              "label": "Eléments",
+              "label": "Elements",
               "englishEntity": "element",
-              "entity": "élément",
+              "entity": "element",
               "field": {
                 "englishLabel": "Element",
-                "label": "Elément",
+                "label": "Element",
                 "fields": [
                   {
                     "englishDescription": "Choose the type of content you would like to add.",
-                    "description": "Sélectionnez le type de contenu que vous souhaitez ajouter."
+                    "description": "Choose the type of content you would like to add."
                   },
                   {},
                   {},
@@ -122,37 +125,37 @@
                   {},
                   {
                     "englishLabel": "Select drop zones",
-                    "label": "Sélectionnez les zones de dépôt"
+                    "label": "Select drop zones"
                   },
                   {
                     "englishLabel": "Background Opacity",
-                    "label": "Opacité du fond"
+                    "label": "Background Opacity"
                   },
                   {
                     "englishLabel": "Infinite number of element instances",
-                    "label": "Nombre illimité d'instances pour cet élément",
+                    "label": "Infinite number of element instances",
                     "englishDescription": "Clones this element so that it can be dragged to multiple drop zones.",
-                    "description": "Cloner cet élément de sorte qu'il puisse être déposé dans plusieurs zones."
+                    "description": "Clones this element so that it can be dragged to multiple drop zones."
                   }
                 ]
               }
             },
             {
               "englishLabel": "Drop Zones",
-              "label": "Zones de dépôt",
+              "label": "Drop Zones",
               "englishEntity": "Drop Zone",
-              "entity": "Zone de dépôt",
+              "entity": "Drop Zone",
               "field": {
                 "englishLabel": "Drop Zone",
-                "label": "Zone de dépôt",
+                "label": "Drop Zone",
                 "fields": [
                   {
                     "englishLabel": "Label",
-                    "label": "Etiquette"
+                    "label": "Label"
                   },
                   {
                     "englishLabel": "Show label",
-                    "label": "Afficher l'étiquette"
+                    "label": "Show label"
                   },
                   {},
                   {},
@@ -160,39 +163,41 @@
                   {},
                   {
                     "englishLabel": "Select correct elements",
-                    "label": "Sélectionnez les éléments qui devront être correctement placés dans cette zone"
+                    "label": "Select correct elements"
                   },
                   {
                     "englishLabel": "Background Opacity",
-                    "label": "Opacité"
+                    "label": "Background Opacity"
                   },
                   {
                     "englishLabel": "Border color",
-                    "label": "Couleur de la bordure",
+                    "label": "Border color",
                     "englishDescription": "The color of the dropzone border (if displayed)",
-                    "description": "La couleur de la bordure de cette zone de dépôt (lors de son affichage)"
+                    "description": "The color of the dropzone border (if displayed)",
+                    "englishDefault": "#666",
+                    "default": "#666"
                   },
                   {
                     "englishLabel": "Tip",
-                    "label": "Indice",
+                    "label": "Tip",
                     "fields": [
                       {
                         "englishLabel": "Tip text",
-                        "label": "Texte de l'indice"
+                        "label": "Tip text"
                       }
                     ]
                   },
                   {
                     "englishLabel": "This drop zone can only contain one element",
-                    "label": "Cette zone de dépôt ne peut contenir qu'un seul élément",
+                    "label": "This drop zone can only contain one element",
                     "englishDescription": "Make sure there is only one correct answer for this dropzone",
-                    "description": "Assurez-vous qu'il n'existe qu'une seule bonne réponse pour cette zone"
+                    "description": "Make sure there is only one correct answer for this dropzone"
                   },
                   {
                     "englishLabel": "Enable Auto-Align",
-                    "label": "Activer l'alignement automatique des éléments déplacés",
+                    "label": "Enable Auto-Align",
                     "englishDescription": "Will auto-align all draggables dropped in this zone.",
-                    "description": "Les éléments déposés dans cette zone seront automatiquement alignés si cette option est cochée."
+                    "description": "Will auto-align all draggables dropped in this zone."
                   }
                 ]
               }
@@ -203,39 +208,39 @@
     },
     {
       "englishLabel": "Background opacity for drop zones",
-      "label": "Opacité des zones de dépôt",
+      "label": "Background opacity for drop zones",
       "englishDescription": "If this field is set, it will override opacity set on all dropzones. This should be a number between 0 and 100, where 0 means full transparency and 100 means no transparency",
-      "description": "Si vous remplissez ce champ, la valeur d'opacité choisie écrasera l'opacité paramétrée pour toutes les zones de dépôt. Cette valeur doit être un nombre compris entre 0 and 100, où 0 correspond à une transparence absolue and 100 à une opacité complète."
+      "description": "If this field is set, it will override opacity set on all dropzones. This should be a number between 0 and 100, where 0 means full transparency and 100 means no transparency"
     },
     {
       "englishLabel": "Background opacity for draggables",
-      "label": "Opacité des étiquettes",
+      "label": "Background opacity for draggables",
       "englishDescription": "If this field is set, it will override opacity set on all draggable elements. This should be a number between 0 and 100, where 0 means full transparency and 100 means no transparency",
-      "description": "Si vous remplissez ce champ, la valeur d'opacité choisie écrasera l'opacité paramétrée pour toutes les étiquettes. Cette valeur doit être un nombre compris entre 0 and 100, où 0 correspond à une transparence absolue and 100 à une opacité complète."
+      "description": "If this field is set, it will override opacity set on all draggable elements. This should be a number between 0 and 100, where 0 means full transparency and 100 means no transparency"
     },
     {
-      "englishLabel": "Behavioural settings.",
-      "label": "Options générales.",
+      "englishLabel": "Behavioural settings",
+      "label": "Behavioural settings",
       "englishDescription": "These options will let you control how the task behaves.",
-      "description": "Cette option vous permet de paramétrer le déroulement de l'exercice.",
+      "description": "These options will let you control how the task behaves.",
       "fields": [
         {
           "englishLabel": "Enable \"Retry\"",
-          "label": "Activer le bouton \"Recommencer\""
+          "label": "Enable \"Retry\""
         },
         {
           "englishLabel": "Give one point for the whole task",
-          "label": "Donner un point pour l'ensemble de l'exercice",
+          "label": "Give one point for the whole task",
           "englishDescription": "Disable to give one point for each draggable that is placed correctly.",
-          "description": "Désactivez cette option pour attribuer un point pour chaque étiquette correctement placée."
+          "description": "Disable to give one point for each draggable that is placed correctly."
         },
         {
           "englishLabel": "Enable score explanation",
-          "label": "Activer les explications du score"
+          "label": "Enable score explanation"
         },
         {
           "englishLabel": "Require user input before the solution can be viewed",
-          "label": "Obliger l'utilisateur à saisir une réponse avant de pouvoir afficher la correction."
+          "label": "Require user input before the solution can be viewed"
         }
       ]
     }

--- a/library.json
+++ b/library.json
@@ -54,6 +54,11 @@
       "machineName": "H5PEditor.DragQuestion",
       "majorVersion": 1,
       "minorVersion": 5
+    },
+    {
+      "machineName": "H5PEditor.ColorSelector",
+      "majorVersion": 1,
+      "minorVersion": 1
     }
   ]
 }

--- a/library.json
+++ b/library.json
@@ -53,7 +53,7 @@
     {
       "machineName": "H5PEditor.DragQuestion",
       "majorVersion": 1,
-      "minorVersion": 5
+      "minorVersion": 6
     },
     {
       "machineName": "H5PEditor.ColorSelector",

--- a/semantics.json
+++ b/semantics.json
@@ -123,6 +123,72 @@
             "min": 0,
             "default": 2,
             "optional": true
+          },
+          {
+            "name": "backgroundColor",
+            "type": "text",
+            "label": "Task Background color",
+            "importance": "low",
+            "description": "The color of the task background (if no image)",
+            "optional": true,
+            "default": "#fff",
+            "widget": "colorSelector",
+            "spectrum": {
+              "showInput": true,
+              "showAlpha": true,
+              "preferredFormat": "rgb",
+              "showPalette": true,
+              "palette": [
+                ["rgba(255, 255, 255, 0)"],
+                [ "rgb(67, 67, 67)", "rgb(102, 102, 102)",
+                "rgb(204, 204, 204)", "rgb(217, 217, 217)","rgb(255, 255, 255)"],
+                ["rgb(152, 0, 0)", "rgb(255, 0, 0)", "rgb(255, 153, 0)", "rgb(255, 255, 0)", "rgb(0, 255, 0)",
+                "rgb(0, 255, 255)", "rgb(74, 134, 232)", "rgb(0, 0, 255)", "rgb(153, 0, 255)", "rgb(255, 0, 255)"],
+                ["rgb(230, 184, 175)", "rgb(244, 204, 204)", "rgb(252, 229, 205)", "rgb(255, 242, 204)", "rgb(217, 234, 211)",
+                "rgb(208, 224, 227)", "rgb(201, 218, 248)", "rgb(207, 226, 243)", "rgb(217, 210, 233)", "rgb(234, 209, 220)",
+                "rgb(221, 126, 107)", "rgb(234, 153, 153)", "rgb(249, 203, 156)", "rgb(255, 229, 153)", "rgb(182, 215, 168)",
+                "rgb(162, 196, 201)", "rgb(164, 194, 244)", "rgb(159, 197, 232)", "rgb(180, 167, 214)", "rgb(213, 166, 189)",
+                "rgb(204, 65, 37)", "rgb(224, 102, 102)", "rgb(246, 178, 107)", "rgb(255, 217, 102)", "rgb(147, 196, 125)",
+                "rgb(118, 165, 175)", "rgb(109, 158, 235)", "rgb(111, 168, 220)", "rgb(142, 124, 195)", "rgb(194, 123, 160)",
+                "rgb(166, 28, 0)", "rgb(204, 0, 0)", "rgb(230, 145, 56)", "rgb(241, 194, 50)", "rgb(106, 168, 79)",
+                "rgb(69, 129, 142)", "rgb(60, 120, 216)", "rgb(61, 133, 198)", "rgb(103, 78, 167)", "rgb(166, 77, 121)",
+                "rgb(91, 15, 0)", "rgb(102, 0, 0)", "rgb(120, 63, 4)", "rgb(127, 96, 0)", "rgb(39, 78, 19)",
+                "rgb(12, 52, 61)", "rgb(28, 69, 135)", "rgb(7, 55, 99)", "rgb(32, 18, 77)", "rgb(76, 17, 48)"]
+              ]
+            }
+          },
+          {
+            "name": "overrideBorderColor",
+            "type": "text",
+            "label": "Border color for drop zones",
+            "importance": "low",
+            "description": "If this color is set, it will override the color of the individual dropzones borders",
+            "optional": true,
+            "default": "rgba(255, 255, 255, 0)",
+            "widget": "colorSelector",
+            "spectrum": {
+              "showInput": true,
+              "showAlpha": true,
+              "preferredFormat": "rgb",
+              "showPalette": true,
+              "palette": [
+                ["rgba(255, 255, 255, 0)"],
+                [ "rgb(67, 67, 67)", "rgb(102, 102, 102)",
+                "rgb(204, 204, 204)", "rgb(217, 217, 217)","rgb(255, 255, 255)"],
+                ["rgb(152, 0, 0)", "rgb(255, 0, 0)", "rgb(255, 153, 0)", "rgb(255, 255, 0)", "rgb(0, 255, 0)",
+                "rgb(0, 255, 255)", "rgb(74, 134, 232)", "rgb(0, 0, 255)", "rgb(153, 0, 255)", "rgb(255, 0, 255)"],
+                ["rgb(230, 184, 175)", "rgb(244, 204, 204)", "rgb(252, 229, 205)", "rgb(255, 242, 204)", "rgb(217, 234, 211)",
+                "rgb(208, 224, 227)", "rgb(201, 218, 248)", "rgb(207, 226, 243)", "rgb(217, 210, 233)", "rgb(234, 209, 220)",
+                "rgb(221, 126, 107)", "rgb(234, 153, 153)", "rgb(249, 203, 156)", "rgb(255, 229, 153)", "rgb(182, 215, 168)",
+                "rgb(162, 196, 201)", "rgb(164, 194, 244)", "rgb(159, 197, 232)", "rgb(180, 167, 214)", "rgb(213, 166, 189)",
+                "rgb(204, 65, 37)", "rgb(224, 102, 102)", "rgb(246, 178, 107)", "rgb(255, 217, 102)", "rgb(147, 196, 125)",
+                "rgb(118, 165, 175)", "rgb(109, 158, 235)", "rgb(111, 168, 220)", "rgb(142, 124, 195)", "rgb(194, 123, 160)",
+                "rgb(166, 28, 0)", "rgb(204, 0, 0)", "rgb(230, 145, 56)", "rgb(241, 194, 50)", "rgb(106, 168, 79)",
+                "rgb(69, 129, 142)", "rgb(60, 120, 216)", "rgb(61, 133, 198)", "rgb(103, 78, 167)", "rgb(166, 77, 121)",
+                "rgb(91, 15, 0)", "rgb(102, 0, 0)", "rgb(120, 63, 4)", "rgb(127, 96, 0)", "rgb(39, 78, 19)",
+                "rgb(12, 52, 61)", "rgb(28, 69, 135)", "rgb(7, 55, 99)", "rgb(32, 18, 77)", "rgb(76, 17, 48)"]
+              ]
+            }
           }
         ]
       },
@@ -275,6 +341,39 @@
                   "optional": true
                 },
                 {
+                  "name": "bordercolor",
+                  "type": "text",
+                  "label": "Border color",
+                  "importance": "low",
+                  "description": "The color of the dropzone border (if displayed)",
+                  "optional": true,
+                  "default": "#666",
+                  "widget": "colorSelector",
+                  "spectrum": {
+                    "showInput": true,
+                    "showAlpha": true,
+                    "preferredFormat": "rgb",
+                    "showPalette": true,
+                    "palette": [
+                      ["rgba(255, 255, 255, 0)"],
+                      [ "rgb(67, 67, 67)", "rgb(102, 102, 102)",
+                      "rgb(204, 204, 204)", "rgb(217, 217, 217)","rgb(255, 255, 255)"],
+                      ["rgb(152, 0, 0)", "rgb(255, 0, 0)", "rgb(255, 153, 0)", "rgb(255, 255, 0)", "rgb(0, 255, 0)",
+                      "rgb(0, 255, 255)", "rgb(74, 134, 232)", "rgb(0, 0, 255)", "rgb(153, 0, 255)", "rgb(255, 0, 255)"],
+                      ["rgb(230, 184, 175)", "rgb(244, 204, 204)", "rgb(252, 229, 205)", "rgb(255, 242, 204)", "rgb(217, 234, 211)",
+                      "rgb(208, 224, 227)", "rgb(201, 218, 248)", "rgb(207, 226, 243)", "rgb(217, 210, 233)", "rgb(234, 209, 220)",
+                      "rgb(221, 126, 107)", "rgb(234, 153, 153)", "rgb(249, 203, 156)", "rgb(255, 229, 153)", "rgb(182, 215, 168)",
+                      "rgb(162, 196, 201)", "rgb(164, 194, 244)", "rgb(159, 197, 232)", "rgb(180, 167, 214)", "rgb(213, 166, 189)",
+                      "rgb(204, 65, 37)", "rgb(224, 102, 102)", "rgb(246, 178, 107)", "rgb(255, 217, 102)", "rgb(147, 196, 125)",
+                      "rgb(118, 165, 175)", "rgb(109, 158, 235)", "rgb(111, 168, 220)", "rgb(142, 124, 195)", "rgb(194, 123, 160)",
+                      "rgb(166, 28, 0)", "rgb(204, 0, 0)", "rgb(230, 145, 56)", "rgb(241, 194, 50)", "rgb(106, 168, 79)",
+                      "rgb(69, 129, 142)", "rgb(60, 120, 216)", "rgb(61, 133, 198)", "rgb(103, 78, 167)", "rgb(166, 77, 121)",
+                      "rgb(91, 15, 0)", "rgb(102, 0, 0)", "rgb(120, 63, 4)", "rgb(127, 96, 0)", "rgb(39, 78, 19)",
+                      "rgb(12, 52, 61)", "rgb(28, 69, 135)", "rgb(7, 55, 99)", "rgb(32, 18, 77)", "rgb(76, 17, 48)"]
+                    ]
+                  }
+                },
+                {
                   "name": "tip",
                   "type": "group",
                   "label": "Tip",
@@ -318,6 +417,14 @@
         ]
       }
     ]
+  },
+  {
+    "name": "backgroundOpacityDropZones",
+    "type": "number",
+    "label": "Background opacity for drop zones",
+    "importance": "low",
+    "description": "If this field is set, it will override opacity set on all dropzones. This should be a number between 0 and 100, where 0 means full transparency and 100 means no transparency",
+    "optional": true
   },
   {
     "name": "backgroundOpacity",


### PR DESCRIPTION
Adds settings for individual drop zones border color (with override).
Border drop zone color is also used for drop zone label and tip color.
Adds a Background opacity for drop zones override setting.
Adds a Task Background color (used if no Background image eelected).
Plus a few minor changes in CSS.
_Signed-off-by: Joseph Rézeau <joseph@rezeau.org>_