### PR TITLE
Update semantics.json

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -378,13 +378,6 @@
         "optional": true
       },
       {
-        "label": "Require user input before the solution can be viewed",
-        "importance": "low",
-        "name": "showSolutionsRequiresInput",
-        "type": "boolean",
-        "default": true
-      },
-      {
         "name": "singlePoint",
         "type": "boolean",
         "label": "Give one point for the whole task",


### PR DESCRIPTION
Removed option "Require user input before the solution can be viewed". This option does not do anything and has caused some confusion from users. 