### PR TITLE
visually hiding labels when they arent displayed, but always loading them.

### DIFF
--- a/css/dragquestion.css
+++ b/css/dragquestion.css
@@ -168,6 +168,15 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
   position: absolute;
 }
 
+.h5p-dragquestion .h5p-dropzone.h5p-label-hidden .h5p-label{
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  word-wrap: normal;
+}
+
 .h5p-dragquestion .h5p-dropzone > .h5p-inner {
   height: 100%;
   position: relative;

--- a/semantics.json
+++ b/semantics.json
@@ -193,7 +193,8 @@
                   "name": "showLabel",
                   "type": "boolean",
                   "label": "Show label",
-                  "importance": "low"
+                  "importance": "low",
+                  "description": "Even when hidden, this is the alternative text provided for visually impaired users. Make sure you don't give away the answer."
                 },
                 {
                   "name": "x",

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -56,7 +56,6 @@ export default class DropZone {
     self.$dropZone = $('<div/>', {
       class: 'h5p-dropzone' + extraClass,
       tabindex: '-1',
-      //title: $('<div/>', {html: self.label}).text(),
       role: 'button',
       'aria-disabled': true,
       css: {

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -43,11 +43,12 @@ export default class DropZone {
     var self = this;
 
     // Prepare inner html with prefix for good a11y
-    var html = '<div class="h5p-inner"></div>';
+    var html = '<div class="h5p-label">' + self.label + '<span class="h5p-hidden-read"></span></div><div class="h5p-inner"></div>';
     var extraClass = '';
     if (self.showLabel) {
-      html = '<div class="h5p-label">' + self.label + '<span class="h5p-hidden-read"></span></div>' + html;
       extraClass = ' h5p-has-label';
+    } else {
+      extraClass = ' h5p-label-hidden';
     }
     html = '<span class="h5p-hidden-read">' + (self.l10n.prefix.replace('{num}', self.id + 1)) + '</span>' + html;
 
@@ -55,7 +56,7 @@ export default class DropZone {
     self.$dropZone = $('<div/>', {
       class: 'h5p-dropzone' + extraClass,
       tabindex: '-1',
-      title: self.showLabel ? $('<div/>', {html: self.label}).text() : null,
+      //title: $('<div/>', {html: self.label}).text(),
       role: 'button',
       'aria-disabled': true,
       css: {


### PR DESCRIPTION
- Add a visually-hidden class to the css
- Apply that to the drop-zone label when it is hidden
- Add help text to the label field to remind authors not to give away the answers when creating labels.