### PR TITLE
Use user defined hover text for images in tasks

### DIFF
--- a/src/drag-question.js
+++ b/src/drag-question.js
@@ -522,6 +522,12 @@ C.prototype.createQuestionContent = function () {
       // Add static element
       var $element = this.addElement(element, 'static', i);
       H5P.newRunnable(element.type, this.id, $element);
+
+      // Override image hover and use user defined hover text or none
+      if (element.type.library.indexOf('H5P.Image ') === 0) {
+        $element.find('img').attr('title', element.type.params.title || '');
+      }
+
       var timedOutOpacity = function ($el, el) {
         setTimeout(function () {
           DragUtils.setOpacity($el, 'background', el.backgroundOpacity);

--- a/src/draggable.js
+++ b/src/draggable.js
@@ -184,7 +184,6 @@ export default class Draggable extends H5P.EventDispatcher {
           }
         }
       }).css('position', '');
-
     self.element = element;
 
     if (element.position) {

--- a/src/draggable.js
+++ b/src/draggable.js
@@ -184,6 +184,7 @@ export default class Draggable extends H5P.EventDispatcher {
           }
         }
       }).css('position', '');
+
     self.element = element;
 
     if (element.position) {
@@ -194,6 +195,11 @@ export default class Draggable extends H5P.EventDispatcher {
 
     DragUtils.addHover(element.$, self.backgroundOpacity);
     H5P.newRunnable(self.type, contentId, element.$);
+
+    // Override image hover and use user defined hover text or none
+    if (self.type.library.indexOf('H5P.Image ') === 0) {
+      element.$.find('img').attr('title', self.type.params.title || '');
+    }
 
     // Add prefix for good a11y
     $('<span class="h5p-hidden-read">' + (self.l10n.prefix.replace('{num}', self.id + 1)) + '</span>').prependTo(element.$);


### PR DESCRIPTION
With changing the image hover handling when metadata were introduced, static images and draggable used the image's metadata title for the hover text, but not what the user specified in the editor of Drag-and-Drop.

This change overrides the image hover text for static images and draggable. It will be what's specified by the user, so possibly empty and not displayed at all. For draggables, the hover for both, the draggable container and the image itself will now be the same.