### PR TITLE
Add audio on drag and drop

### DIFF
--- a/css/dragquestion.css
+++ b/css/dragquestion.css
@@ -287,3 +287,7 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
   top: -0.15em;
   right: -0.15em;
 }
+
+.h5p-dragquestion .h5p-dragquestion-no-display {
+  display: none;
+}

--- a/language/.en.json
+++ b/language/.en.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/.en.json
+++ b/language/.en.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/af.json
+++ b/language/af.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/af.json
+++ b/language/af.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/ar.json
+++ b/language/ar.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "الاعدادات السلوكية",
       "description": "ستتيح لك هذه الخيارات التحكم في كيفية تصرف المهمة.",
       "fields": [

--- a/language/ar.json
+++ b/language/ar.json
@@ -53,6 +53,20 @@
                   {
                     "label": "عدد لانهائي من حالات العنصر",
                     "description": "استنساخ هذا العنصر بحيث يمكن سحبه إلى مناطق إفلات متعددة."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/bg.json
+++ b/language/bg.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Настройки на поведението",
       "description": "Тези опции ще ви позволят да контролирате поведението на задачата.",
       "fields": [

--- a/language/bg.json
+++ b/language/bg.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Безкраен брой инстанции на елементи",
                     "description": "Копира този елемент, така че да може да се плъзга в няколко зони на пускане."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/bs.json
+++ b/language/bs.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Podešavanje interakcije",
       "description": "Ova opcija kontrolira kako se zadatak ponaša.",
       "fields": [

--- a/language/bs.json
+++ b/language/bs.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Neograničen broj elemenata",
                     "description": "Klonira ovaj element kako bi mogao biti spušten na višestruke zone."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/ca.json
+++ b/language/ca.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Nombre infinit d’instàncies d’elements",
                     "description": "Clona aquest element perquè es pugui arrossegar a diferents zones per deixar anar."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/ca.json
+++ b/language/ca.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Opcions de comportament",
       "description": "Aquestes opcions et permetran controlar com es comporta la tasca.",
       "fields": [

--- a/language/cs.json
+++ b/language/cs.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Nastavení chování",
       "description": "Tyto možnosti vám umožní řídit, jak se bude úloha chovat.",
       "fields": [

--- a/language/cs.json
+++ b/language/cs.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Nekonečný počet instancí prvků",
                     "description": "Klonuje tento prvek, takže jej lze přetáhnout do více zón přetažení."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/da.json
+++ b/language/da.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/da.json
+++ b/language/da.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Indstillinger for opgave-opførsel",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/de.json
+++ b/language/de.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Verhaltenseinstellungen",
       "description": "Diese Optionen legen fest, wie die Aufgabe im Detail funktioniert.",
       "fields": [

--- a/language/de.json
+++ b/language/de.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Element kann mehrfach in Ablagezonen gezogen werden",
                     "description": "Wenn dieses Element verschoben wird, werden Kopien davon erstellt, so dass es beliebig oft in verschiedene Ablagezonen gezogen werden kann."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/el.json
+++ b/language/el.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Ρυθμίσεις άσκησης",
       "description": "Αυτές οι ρυθμίσεις σας επιτρέπουν να καθορίσετε τον τρόπο λειτουργίας της άσκησης.",
       "fields": [

--- a/language/el.json
+++ b/language/el.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Απεριόριστος αριθμός επαναλήψεων στοιχείου",
                     "description": "Δημιουργεί αντίγραφα του στοιχείου έτσι ώστε να μπορεί να συρθεί σε πολλαπλές περιοχές απόθεσης."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Número infinito de instancias de elementos",
                     "description": "Clona este elemento para que pueda ser arrastrado a múltiples zonas de caída."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Ajustes de comportamiento",
       "description": "Estas opciones le permitirán controlar como se comporta el trabajo.",
       "fields": [

--- a/language/es.json
+++ b/language/es.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Número infinito de instancias de elementos",
                     "description": "Clona este elemento para que pueda ser arrastrado a múltiples zonas de caída."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/es.json
+++ b/language/es.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Ajustes de comportamiento",
       "description": "Estas opciones le permitirán controlar como se comporta el trabajo.",
       "fields": [

--- a/language/et.json
+++ b/language/et.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Lõpmatu arv elemendi kloone",
                     "description": "Paljundab elementi, et seda saaks lohistada mitmetesse sihtkohtadesse."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/et.json
+++ b/language/et.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Käitumisseaded",
       "description": "Need valikud võimaldavad sul määrata, kuidas ülesanne käitub.",
       "fields": [

--- a/language/eu.json
+++ b/language/eu.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Jokabideko ezarpenak",
       "description": "Aukera hauen bidez kontrolatu dezakezu zereginaren jokabidea.",
       "fields": [

--- a/language/eu.json
+++ b/language/eu.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Elementu sekuentzia kopuru infinitua",
                     "description": "Elementu hau klonatzen du, hartara elementua hainbat jaregiteko zonatara jaregin daiteke."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/fi.json
+++ b/language/fi.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Yleisasetukset",
       "description": "Näillä valinnoilla voit ohjailla tehtävän toimintoja.",
       "fields": [

--- a/language/fi.json
+++ b/language/fi.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Loputon määrä elementin kopioita",
                     "description": "Kloonaa elementin, jotta sen voi raahata useisiin kohteisiin."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/fr.json
+++ b/language/fr.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Options générales.",
       "description": "Ces options vous permettent de contrôler le déroulement de vos activités.",
       "fields": [

--- a/language/fr.json
+++ b/language/fr.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Nombre illimité d'instances pour cet élément",
                     "description": "Cloner cet élément de sorte qu'il puisse être déposé dans plusieurs zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/he.json
+++ b/language/he.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "הגדרות התנהגות",
       "description": "אפשרויות אלה יתנו לך לשלוט בהתנהגות המשימה.",
       "fields": [

--- a/language/he.json
+++ b/language/he.json
@@ -53,6 +53,20 @@
                   {
                     "label": "מספר אינסופי של רכיבים",
                     "description": "בחרו ברכיב זה כך שיהיה אפשר לגרור אותו למספר אזורי יעד."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/hu.json
+++ b/language/hu.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/hu.json
+++ b/language/hu.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/it.json
+++ b/language/it.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Numero infinito di istanze di elementi",
                     "description": "Clonare questo elemento in modo che possa essere trascinato su più zone di trascinamento."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/it.json
+++ b/language/it.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Impostazioni di esecuzione",
       "description": "Queste opzioni permettono di controllare l'andamento del compito",
       "fields": [

--- a/language/ja.json
+++ b/language/ja.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "動作設定",
       "description": "これらのオプションでタスクがどのように動作するかを制御できます。",
       "fields": [

--- a/language/ja.json
+++ b/language/ja.json
@@ -53,6 +53,20 @@
                   {
                     "label": "要素数無制限",
                     "description": "この要素を複製して、複数のドロップゾーンにドラッグできるようにします。"
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Audio to play when draggable is picked up."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/km.json
+++ b/language/km.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/km.json
+++ b/language/km.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/ko.json
+++ b/language/ko.json
@@ -53,6 +53,20 @@
                   {
                     "label": "무제한의 인스턴스 항목 수",
                     "description": "이 항목을 여러 드롭 영역으로 끌 수 있도록 복제하세요."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/ko.json
+++ b/language/ko.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "행동 설정",
       "description": "이 설정은 과제를 해결하는 과정을 통제.",
       "fields": [

--- a/language/nb.json
+++ b/language/nb.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Uendelig antall instanser av elementet",
                     "description": "Klon dette elementet slik at det kan dras til flere målområder."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/nb.json
+++ b/language/nb.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Innstillinger for oppgaveoppførsel",
       "description": "Disse instillingene lar deg bestemme hvordan oppgavetypen skal oppføre seg.",
       "fields": [

--- a/language/nl.json
+++ b/language/nl.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Gedragsinstellingen",
       "description": "Deze opties bepalen hoe de taak op de input reageert.",
       "fields": [

--- a/language/nl.json
+++ b/language/nl.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Oneindig aantal elementen",
                     "description": "Kloon dit element zodat het naar meerdere neerzetgebieden kan worden gesleept."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/nn.json
+++ b/language/nn.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Uendelig antall instanser av elementet",
                     "description": "Klon dette elementet slik at det kan dras til flere målområder."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/nn.json
+++ b/language/nn.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Innstillinger for oppgave-oppførsel",
       "description": "Disse instillingene lar deg bestemme hvordan oppgavetypen skal oppføre seg.",
       "fields": [

--- a/language/pl.json
+++ b/language/pl.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Nieskończona liczba instancji elementu",
                     "description": "Powiela ten element, aby można go było przeciągnąć do wielu obszarów przeciągania."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/pl.json
+++ b/language/pl.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Ustawienia zachowania",
       "description": "Te opcje pozwalają kontrolować zachowanie zadania.",
       "fields": [

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Configurações comportamentais",
       "description": "Estas opções permitirão que você controle como a tarefa se comporta.",
       "fields": [

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Número infinito de instâncias do elemento",
                     "description": "Clona este elemento para que ele possa ser arrastado para múltiplas zonas de largada."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/pt.json
+++ b/language/pt.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Número infinito de instâncias de elementos",
                     "description": "Duplicar este elemento para que possa ser arrastado para múltiplas zonas."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/pt.json
+++ b/language/pt.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Definições de funcionamento",
       "description": "Estas opções permitem-lhe controlar o funcionamento desta atividade.",
       "fields": [

--- a/language/ro.json
+++ b/language/ro.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/ro.json
+++ b/language/ro.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/ru.json
+++ b/language/ru.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Настройки поведения",
       "description": "Эти параметры позволят вам контролировать поведение задачи.",
       "fields": [

--- a/language/ru.json
+++ b/language/ru.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Бесконечное количество экземпляров элемента",
                     "description": "Клонирует этот элемент, чтобы его можно было перетащить в несколько областей размещения."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/sl.json
+++ b/language/sl.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Nastavitve interakcije",
       "description": "Nastavitve omogočajo nadzor nad interakcijo aktivnosti za udeležence.",
       "fields": [

--- a/language/sl.json
+++ b/language/sl.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Omogoči neskončno možnost izbire elementa (kloniranje)",
                     "description": "Klone tega elementa bo možno povleči v več spustnih polj."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/sma.json
+++ b/language/sma.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/sma.json
+++ b/language/sma.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/sme.json
+++ b/language/sme.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/sme.json
+++ b/language/sme.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/smj.json
+++ b/language/smj.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/smj.json
+++ b/language/smj.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/sr.json
+++ b/language/sr.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/sr.json
+++ b/language/sr.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/sv.json
+++ b/language/sv.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/sv.json
+++ b/language/sv.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/tr.json
+++ b/language/tr.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/tr.json
+++ b/language/tr.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Davranış ayarları",
       "description": "Bu seçenekler aktivitenin çalışma şeklini denetlemenize izin verir.",
       "fields": [

--- a/language/uk.json
+++ b/language/uk.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Нескінченна кількість екземплярів елемента",
                     "description": "Клонує цей елемент, щоб його можна було перетягнути в декілька областей розміщення."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/uk.json
+++ b/language/uk.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Настройки поведінки",
       "description": "Ці параметри дозволять вам контролювати поведінку завдання.",
       "fields": [

--- a/language/vi.json
+++ b/language/vi.json
@@ -53,6 +53,20 @@
                   {
                     "label": "Infinite number of element instances",
                     "description": "Clones this element so that it can be dragged to multiple drop zones."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/vi.json
+++ b/language/vi.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "Behavioural settings",
       "description": "These options will let you control how the task behaves.",
       "fields": [

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -53,6 +53,20 @@
                   {
                     "label": "元素无限化",
                     "description": "勾选后可使元素能拖曳至多个任务区域."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "行为设定",
       "description": "这些选项将可让您控制任务的行为.",
       "fields": [

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -53,6 +53,20 @@
                   {
                     "label": "元素無限化",
                     "description": "勾選後可使元素能拖曳至多個任務區域."
+                  },
+                  {
+                    "label": "Audio",
+                    "description": "Audio samples",
+                    "fields": [
+                      {
+                        "label": "Picked up",
+                        "description": "Custom audio to play when draggable is picked up. Will override general audio setting."
+                      },
+                      {
+                        "label": "Dropped",
+                        "description": "Custom audio to play when draggable is dropped. Will override general audio setting."
+                      }
+                    ]
                   }
                 ]
               }
@@ -142,7 +156,7 @@
       "description": "Audio samples",
       "fields": [
         {
-          "label": "Pick up",
+          "label": "Picked up",
           "description": "Audio to play when draggable is picked up."
         },
         {

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -138,6 +138,28 @@
       ]
     },
     {
+      "label": "Audio",
+      "description": "Audio samples",
+      "fields": [
+        {
+          "label": "Pick up",
+          "description": "Audio to play when draggable is picked up."
+        },
+        {
+          "label": "Dropped",
+          "description": "Audio to generally play when draggable is dropped."
+        },
+        {
+          "label": "Dropped correctly",
+          "description": "Audio to play when draggable is dropped on correct dropzone."
+        },
+        {
+          "label": "Dropped wrong",
+          "description": "Audio to play when draggable is dropped on wrong dropzone."
+        }
+      ]
+    },
+    {
       "label": "行為設定",
       "description": "這些選項將可讓您控制任務的行為.",
       "fields": [

--- a/semantics.json
+++ b/semantics.json
@@ -145,6 +145,30 @@
                   "importance": "low",
                   "description": "Clones this element so that it can be dragged to multiple drop zones.",
                   "default": false
+                },
+                {
+                  "name": "audio",
+                  "type": "group",
+                  "label": "Audio",
+                  "importance": "low",
+                  "description": "Audio samples",
+                  "optional": true,
+                  "fields": [
+                    {
+                      "name": "pickedUp",
+                      "type": "audio",
+                      "label": "Picked up",
+                      "description": "Custom audio to play when draggable is picked up. Will override general audio setting.",
+                      "importance": "low"
+                    },
+                    {
+                      "name": "dropped",
+                      "type": "audio",
+                      "label": "Dropped",
+                      "description": "Custom Custom audio to play when draggable is dropped. Will override general audio setting.",
+                      "importance": "low"
+                    }
+                  ]
                 }
               ]
             }
@@ -350,7 +374,7 @@
       {
         "name": "pickedUp",
         "type": "audio",
-        "label": "Pick up",
+        "label": "Picked up",
         "description": "Audio to play when draggable is picked up.",
         "importance": "low"
       },

--- a/semantics.json
+++ b/semantics.json
@@ -340,6 +340,44 @@
     ]
   },
   {
+    "name": "audio",
+    "type": "group",
+    "label": "Audio",
+    "importance": "low",
+    "description": "Audio samples",
+    "optional": true,
+    "fields": [
+      {
+        "name": "pickedUp",
+        "type": "audio",
+        "label": "Pick up",
+        "description": "Audio to play when draggable is picked up.",
+        "importance": "low"
+      },
+      {
+        "name": "dropped",
+        "type": "audio",
+        "label": "Dropped",
+        "description": "Audio to generally play when draggable is dropped.",
+        "importance": "low"
+      },
+      {
+        "name": "droppedCorrect",
+        "type": "audio",
+        "label": "Dropped correctly",
+        "description": "Audio to play when draggable is dropped on correct dropzone.",
+        "importance": "low"
+      },
+      {
+        "name": "droppedWrong",
+        "type": "audio",
+        "label": "Dropped wrong",
+        "description": "Audio to play when draggable is dropped on wrong dropzone.",
+        "importance": "low"
+      }
+    ]
+  },
+  {
     "name": "behaviour",
     "type": "group",
     "label": "Behavioural settings",

--- a/src/drag-question.js
+++ b/src/drag-question.js
@@ -174,6 +174,10 @@ function C(options, contentId, contentData) {
     draggable.on('pickedUp', (event) => {
       const currentDraggable = self.draggables[event.data];
 
+      if (this.taskCompleted) {
+        return;
+      }
+
       this.resetAudios();
 
       if (currentDraggable.audios && currentDraggable.audios.pickedUp) {
@@ -195,7 +199,7 @@ function C(options, contentId, contentData) {
     });
     draggable.on('dragend', function (event) {
       // The special dropped sounds are more important and should not be stopped
-      if (!self.isAudioPlaying(['droppedWrong', 'droppedCorrect'])) {
+      if (!self.isAudioPlaying(['droppedWrong', 'droppedCorrect']) && !this.taskCompleted) {
         self.resetAudios();
 
         const currentDraggable = self.draggables[event.data];
@@ -648,6 +652,7 @@ C.prototype.addSolutionButton = function () {
   var that = this;
 
   this.addButton('check-answer', this.options.scoreShow, function () {
+    that.taskCompleted = true;
     that.answered = true;
     that.showAllSolutions();
     that.showScore();
@@ -935,6 +940,7 @@ C.prototype.resetTask = function () {
   this.points = 0;
   this.rawPoints = 0;
   this.answered = false;
+  this.taskCompleted = false;
 
   this.dropZones.forEach(function (dropzone) {
     dropzone.reset();

--- a/src/drag-question.js
+++ b/src/drag-question.js
@@ -176,7 +176,7 @@ function C(options, contentId, contentData) {
 
       this.resetAudios();
 
-      if (currentDraggable.audios.pickedUp) {
+      if (currentDraggable.audios && currentDraggable.audios.pickedUp) {
         currentDraggable.audios.pickedUp.play();
       }
       else {
@@ -199,7 +199,7 @@ function C(options, contentId, contentData) {
         self.resetAudios();
 
         const currentDraggable = self.draggables[event.data];
-        if (currentDraggable.audios.dropped) {
+        if (currentDraggable.audios && currentDraggable.audios.dropped) {
           currentDraggable.audios.dropped.play();
         }
         else {

--- a/src/draggable.js
+++ b/src/draggable.js
@@ -127,6 +127,15 @@ export default class Draggable extends H5P.EventDispatcher {
       appendTo: $container,
       title: self.type.params.title
     })
+      .on('mousedown', () => {
+        self.trigger('pickedUp');
+      })
+      .on('keydown', (event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') {
+          return;
+        }
+        self.trigger('pickedUp');
+      })
       .on('click', function () {
         self.trigger('focus', this);
       })

--- a/src/draggable.js
+++ b/src/draggable.js
@@ -29,6 +29,7 @@ export default class Draggable extends H5P.EventDispatcher {
     self.type = element.type;
     self.multiple = element.multiple;
     self.l10n = l10n;
+    self.audios = element.audio;
 
     if (answers) {
       if (self.multiple) {
@@ -128,7 +129,7 @@ export default class Draggable extends H5P.EventDispatcher {
       title: self.type.params.title
     })
       .on('mousedown', () => {
-        self.trigger('pickedUp');
+        self.trigger('pickedUp', self.id);
       })
       .on('keydown', (event) => {
         if (event.key !== 'Enter' && event.key !== ' ') {
@@ -151,7 +152,7 @@ export default class Draggable extends H5P.EventDispatcher {
           self.updatePlacement(element);
           $this[0].setAttribute('aria-grabbed', 'false');
 
-          self.trigger('dragend');
+          self.trigger('dragend', self.id);
 
           return !dropZone;
         },
@@ -209,6 +210,28 @@ export default class Draggable extends H5P.EventDispatcher {
 
     // Add suffix for good a11y
     $('<span class="h5p-hidden-read"></span>').appendTo(element.$);
+
+    if (self.audios) {
+      ['pickedUp', 'dropped'].forEach(type => {
+        if (
+          !self.audios[type] ||
+          !Array.isArray(self.audios[type]) ||
+          self.audios[type].length < 1 ||
+          !self.audios[type][0].path ||
+          self.audios[type][0].mime.split('/')[0] !== 'audio'
+        ) {
+          return;
+        }
+
+        // Attach audio element
+        const player = document.createElement('audio');
+        player.classList.add('h5p-dragquestion-no-display');
+        player.src = H5P.getPath(self.audios[type][0].path, contentId);
+
+        self.audios[type] = player;
+        element.$.append(self.audios[type]);
+      });
+    }
 
     // Update opacity when element is attached.
     setTimeout(function () {

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -94,6 +94,13 @@ export default class DropZone {
             return self.accepts(result.draggable, draggables);
           },
           drop: function (event, ui) {
+            // Report dropped element
+            const draggable = DragUtils.elementToDraggable(draggables, ui.draggable);
+            self.trigger('dropped', {
+              draggableId: draggable.draggable.id,
+              dropzoneId: self.id
+            });
+
             var $this = $(this);
             DragUtils.setOpacity($this.removeClass('h5p-over'), 'background', self.backgroundOpacity);
             ui.draggable.data('addToZone', self.id);
@@ -351,7 +358,7 @@ export default class DropZone {
   }
 
   /**
-   * Invoked when reset task is run. Cleanup any internal states. 
+   * Invoked when reset task is run. Cleanup any internal states.
    */
   reset() {
     // Remove alignables


### PR DESCRIPTION
- Allows authors to set audios that will be played when starting to drag or when dropping a draggable (per draggable and globally).
- Allows authors to set audios that will be played when dropping a draggable on a correct or wrong dropzone.