### PR TITLE
HFP-3610 Do not change element position if already in dropzone

### DIFF
--- a/src/drag-question.js
+++ b/src/drag-question.js
@@ -1137,6 +1137,14 @@ var getControls = function (draggables, dropZones, noDropzone) {
 
     var dropZone = DragUtils.elementToDropZone(dropZones, event.element);
 
+    // Don't change anything if element is in selected dropzone already
+    if (selected.element.dropZone === dropZone.id) {
+      // Reset selected
+      selected.element.$[0].setAttribute('aria-grabbed', 'false');
+      deselect();
+      return;
+    }
+
     var mustCopyElement = selected.draggable.mustCopyElement(selected.element);
     if (mustCopyElement) {
       // Leave a new element for next drag


### PR DESCRIPTION
_When merged in, placing a draggable inside a dropbox using the "select" logic is ignored if the element is already inside the dropbox._

Currently it is possible that by accident a dropped item is auto-aligned in a dropzone that should not auto-align. Please compare the report at https://h5p.org/comment/47251.

This can happen if you

1. drop an element in a dropzone, then
2. select the element using a click without dragging and then
3. select the dropbox.

The keyboard select-function is triggered which will always auto-align items. I assume this is a side effect to the recent changes of drag detection (or has always been the case :-)).

By only placing a draggable inside a dropbox using the "select" logic if the element is not already inside the dropbox, the issue can be fixed while the rest of the behavior stays the same.