### PR TITLE
Fix computation of number of draggables

### DIFF
--- a/src/drag-question.js
+++ b/src/drag-question.js
@@ -125,9 +125,14 @@ function C(options, contentId, contentData) {
 
   this.weight = 1;
 
-  // Add draggable elements
+  // Not all "draggables" are draggable, some are static w/o dropzones assigned
+  const numberDraggables = task.elements
+    .filter((element) => element.dropZones.length)
+    .length;
+
+    // Add draggable elements
   var grabbablel10n = {
-    prefix: self.options.grabbablePrefix.replace('{total}', task.elements.length),
+    prefix: self.options.grabbablePrefix.replace('{total}', numberDraggables),
     suffix: self.options.grabbableSuffix,
     correctAnswer: self.options.correctAnswer,
     wrongAnswer: self.options.wrongAnswer


### PR DESCRIPTION
Currently, Drag the Words announces a wrong number of "grabbables" via screen readers when selecting them with the keyboard.

When Drag the Words announces the currently selected "grabbable" via screen readers like "Grabbable 2 of 6", it computes the total number of "grabbables" by counting all "draggables" that the author created. However, those "draggables" can in fact be static and not "draggable/grabbable" if the author did not assign and drop zones.

When the changes of this pull request are merged in, the number of actual "grabbables" is computed correctly by leaving out "draggables" without drop zones assigned to them.