### PR TITLE
VA-1201 Adjust visual appearance

### DIFF
--- a/css/dragquestion.css
+++ b/css/dragquestion.css
@@ -312,9 +312,13 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
   outline: none;
 }
 
+.h5p-dragquestion .h5p-draggable .h5p-question-plus-one-container, .h5p-dragquestion .h5p-draggable .h5p-question-minus-one-container {
+  background-color: hsl(0, 0%, 100%);
+}
+
 .h5p-dragquestion .h5p-question-plus-one, .h5p-dragquestion .h5p-question-minus-one {
   width: 1.25em;
   height: calc(1.25em * 0.638297872);
-  top: -0.15em;
-  right: -0.15em;
+  top: 0;
+  left: 0;
 }

--- a/css/dragquestion.css
+++ b/css/dragquestion.css
@@ -143,6 +143,14 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
   font-size: var(--h5p-theme-font-size-m);
 }
 
+.h5p-dragquestion .h5p-draggable.h5p-correct p {
+  color: var(--h5p-theme-feedback-correct-main);
+}
+
+.h5p-dragquestion .h5p-draggable.h5p-wrong p {
+  color: var(--h5p-theme-feedback-incorrect-main);
+}
+
 .h5p-dragquestion .h5p-draggable img {
   -webkit-user-drag: none;
   pointer-events: none;

--- a/language/.en.json
+++ b/language/.en.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/af.json
+++ b/language/af.json
@@ -201,7 +201,7 @@
           "description": "Ontmerk hierdie opsie as jy nie wil hê dat hierdie titel vertoon moet word nie. Die titel sal slegs in opsommings, statistieke ens. vertoon word."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/ar.json
+++ b/language/ar.json
@@ -201,7 +201,7 @@
           "description": "قم بإلغاء تحديد هذا الخيار إذا كنت لا تريد عرض هذا العنوان. سيتم عرض العنوان فقط في الملخصات والإحصاءات وما إلى ذلك."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/bg.json
+++ b/language/bg.json
@@ -201,7 +201,7 @@
           "description": "Махнете отметката от тази опция, ако не искате заглавието да се показва. То ще се показва само в резюмета, статистически данни и т.н."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/bs.json
+++ b/language/bs.json
@@ -201,7 +201,7 @@
           "description": "Isključi ovu opciju ako ne želiš vidjeti naslov.Naslov će biti prikazan samo u sažecima, statistikama, itd."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/ca.json
+++ b/language/ca.json
@@ -201,7 +201,7 @@
           "description": "Desactiveu aquesta opció si no voleu que es mostri aquest títol. El títol només es mostrarà en resums, estadístiques, etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/cs.json
+++ b/language/cs.json
@@ -201,7 +201,7 @@
           "description": "Zrušte zaškrtnutí této možnosti, pokud nechcete, aby se tento nadpis zobrazoval. Nadpis se zobrazí pouze v souhrnech, statistikách atd."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/da.json
+++ b/language/da.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/de.json
+++ b/language/de.json
@@ -201,7 +201,7 @@
           "description": "Deaktiviere diese Option, falls du nicht möchtest, dass der Titel angezeigt wird. Der Titel wird nur in der Zusammenfassung und in Statistiken eingeblendet."
         },
         {
-          "label": "Sichtbarkeit der Ziehgriffe",
+          "label": "Zeige Ziehgriffe (nur beim neuen Look and Feel)",
           "description": "Ändert die Sichtbarkeit der Ziehgriffe, die zum Verschieben von Elementen auf der Leinwand verwendet werden."
         }
       ]

--- a/language/el.json
+++ b/language/el.json
@@ -201,7 +201,7 @@
           "description": "Αποεπιλέξτε αυτή τη ρύθμιση, εάν δεν επιθυμείτε να εμφανίζεται ο τίτλος. Ο τίτλος θα εμφανίζεται μόνο σε συνόψεις, στατιστικά κ.λπ."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -201,7 +201,7 @@
           "description": "Desactivar esta opción si no desea que se muestre este título. El título solamente será mostrado en resúmenes, estadísticas, etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/es.json
+++ b/language/es.json
@@ -201,7 +201,7 @@
           "description": "Desactivar esta opción si no quieres que se muestre este título. El título solamente se mostrará en resúmenes, estadísticas, etc."
         },
         {
-          "label": "Visibilidad del controlador de arrastre",
+          "label": "Mostrar controladores de arrastre (solo para nueva apariencia y experiencia)",
           "description": "Activa la visibilidad de controladores de arrastre utilizada para mover los elementos del área de trabajo."
         }
       ]

--- a/language/et.json
+++ b/language/et.json
@@ -201,7 +201,7 @@
           "description": "Ära märgi seda valikut, kui ei taha pealkirja näidata. Pealkirja näidatakse ainult kokkuvõtetes, statistikas, jne."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/eu.json
+++ b/language/eu.json
@@ -201,7 +201,7 @@
           "description": "Desmarka ezazu opzio hau ez baduzu nahi titulua erakustea. Titulua bakarrik erakutsiko da laburpenean, estatistiketan eta abar."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/fi.json
+++ b/language/fi.json
@@ -201,7 +201,7 @@
           "description": "Jätä valitsematta, jos et halua otsikkoa näkyviin. Tällöin otsikko näkyy vain yhteenvedoissa, tilastoissa jne."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/fr.json
+++ b/language/fr.json
@@ -201,7 +201,7 @@
           "description": "Décochez cette option si vous ne voulez pas que ce titre soit affiché. Le titre ne sera affiché que dans les résumés, les statistiques, etc."
         },
         {
-          "label": "Visibilité des Poignées de Déplacement",
+          "label": "Montrer les Poignées de Déplacement (nouveau look uniquement)",
           "description": "Change l'état de visibilité des poignées permettant de déplacer des éléments sur le canevas"
         }
       ]

--- a/language/gl.json
+++ b/language/gl.json
@@ -201,7 +201,7 @@
           "description": "Desmarca esta opción se non queres que se amose este título. O título amosarase só en resumos, estatísticas, etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/he.json
+++ b/language/he.json
@@ -201,7 +201,7 @@
           "description": "הורדת סימון מאפשרות זו אם אתם לא רוצים שכותרת זו תוצג. הכותרת תוצג בתקצירים, סטטיסטיקות וכו'."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/hu.json
+++ b/language/hu.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/it.json
+++ b/language/it.json
@@ -201,7 +201,7 @@
           "description": "Deseleziona questa opzione se non vuoi che questo titolo sia visualizzato. Il titolo sarà visualizzato solo in sintesi, statistiche ecc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/ja.json
+++ b/language/ja.json
@@ -201,7 +201,7 @@
           "description": "このタイトルを表示したくない場合は、このオプションをオフにします。タイトルは概要、統計などでのみ表示されます。"
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/ka.json
+++ b/language/ka.json
@@ -201,7 +201,7 @@
           "description": "გამორთეთ ეს პარამეტრი თუ არ გინდათ, რომ სათაური გამოჩნდეს. სათაური გამოჩნდება მხოლოდ დავალების ბოლოში, სტატისტიკაში და ა.შ."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/km.json
+++ b/language/km.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/ko.json
+++ b/language/ko.json
@@ -201,7 +201,7 @@
           "description": "이 제목을 표시하지 않으려면 이 옵션의 선택을 취소하십시오. 제목은 요약, 통계 등에만 표시."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/lt.json
+++ b/language/lt.json
@@ -201,7 +201,7 @@
           "description": "Išjunkite šį parametrą, jei nenorite rodyti pavadinimo. Pavadinimas bus rodomas tik pabaigoje, statistikoje ir t.t."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/lv.json
+++ b/language/lv.json
@@ -201,7 +201,7 @@
           "description": "Noņemiet šo atzīmi, ja nevēlaties, lai šis virsraksts tiktu rādīts. Virsraksts tiks parādīts tikai kopsavilkumos, statistikā utt."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/mn.json
+++ b/language/mn.json
@@ -201,7 +201,7 @@
           "description": "Хэрэв та энэ гарчгийг харуулахыг хүсэхгүй байгаа бол энэ сонголтыг арилгана уу. Гарчиг нь зөвхөн хураангуй, статистик гэх мэтээр харагдах болно."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/nb.json
+++ b/language/nb.json
@@ -201,7 +201,7 @@
           "description": "Fjern hake hvis du ikke ønsker å vise tittelen. Tittelen vises bare ved oppsummeringer, statistikk osv."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/nl.json
+++ b/language/nl.json
@@ -201,7 +201,7 @@
           "description": "Vink deze optie uit als je de titel niet wilt tonen. De titel wordt alleen getoond in samenvattingen, statistieken enz."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/nn.json
+++ b/language/nn.json
@@ -201,7 +201,7 @@
           "description": "Fjern hake om du ikkje vil vise tittelen. Tittelen er synleg berre ved oppsummeringar, statistikk osb."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/pl.json
+++ b/language/pl.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -201,7 +201,7 @@
           "description": "Desmarque esta opção se você não quiser que este título seja exibido. O título só será exibido em resumos, estatísticas, etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/pt.json
+++ b/language/pt.json
@@ -201,7 +201,7 @@
           "description": "Desmarque esta opção se não pretender que este título seja exibido. O título será exibido apenas em resumos, estatísticas, etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/ro.json
+++ b/language/ro.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/ru.json
+++ b/language/ru.json
@@ -201,7 +201,7 @@
           "description": "Отключите настройку, если не хотите, чтобы заголовок отобрадался. Заголовок отобразится лишь в заключении, статистике и тд."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/sl.json
+++ b/language/sl.json
@@ -201,7 +201,7 @@
           "description": "Naslov vsebine bo skrit."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/sma.json
+++ b/language/sma.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/sme.json
+++ b/language/sme.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/smj.json
+++ b/language/smj.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/sr.json
+++ b/language/sr.json
@@ -201,7 +201,7 @@
           "description": "Опозовите избор ове опције ако не желите да се приказује овај наслов. Наслов ће бити приказан само у резимеима, статистикама итд."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/sv.json
+++ b/language/sv.json
@@ -201,7 +201,7 @@
           "description": "Bocka ur detta om du vill att din titel inte ska visas. Titeln kommer bara visas i sammanfattningar, statistik, etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/sw.json
+++ b/language/sw.json
@@ -201,7 +201,7 @@
           "description": "Futa chaguo hili ikiwa hutaki mada hii ionyeshwe. Mada itaonyeshwa tu katika muhtasari, takwimu na kadhalika."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/th.json
+++ b/language/th.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/tr.json
+++ b/language/tr.json
@@ -201,7 +201,7 @@
           "description": "Başlığın gösterilmesini istemiyorsanız bu seçenekteki işareti kaldırınız. Başlık sadece özetlerde,istatistiklerde vb. yerlerde gösterilecektir."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/uk.json
+++ b/language/uk.json
@@ -201,7 +201,7 @@
           "description": "Зніміть цей прапорець, якщо ви не хочете, щоб ця назва відображалася. Заголовок відображатиметься лише у резюме, статистиці тощо."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/vi.json
+++ b/language/vi.json
@@ -201,7 +201,7 @@
           "description": "Uncheck this option if you do not want this title to be displayed. The title will only be displayed in summaries, statistics etc."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -201,7 +201,7 @@
           "description": "如果不希望显示标题时，请取消勾选此选项。标题将只显示在总结、统计等."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -201,7 +201,7 @@
           "description": "如果不希望顯示標題時，請取消勾選此選項。標題將只顯示在總結、統計等."
         },
         {
-          "label": "Drag handle visibility",
+          "label": "Show drag handles (new look and feel only)",
           "description": "Toggles the visibility of drag handles used to move elements on the canvas."
         }
       ]

--- a/semantics.json
+++ b/semantics.json
@@ -473,7 +473,7 @@
       {
         "name": "dragHandleVisibility",
         "type": "boolean",
-        "label": "Drag handle visibility",
+        "label": "Show drag handles (new look and feel only)",
         "description": "Toggles the visibility of drag handles used to move elements on the canvas.",
         "importance": "low",
         "default": true

--- a/src/drag-question.js
+++ b/src/drag-question.js
@@ -169,7 +169,7 @@ function C(options, contentId, contentData) {
     );
     var highlightDropZones = (self.options.behaviour.dropZoneHighlighting === 'dragging');
     draggable.on('elementadd', function (event) {
-      // controls.drag.addElement(event.data);
+      controls.drag.addElement(event.data);
     });
     draggable.on('elementremove', function (event) {
       controls.drag.removeElement(event.data);


### PR DESCRIPTION
When merged in, will
- give the score feedback a white background,
- use the default correctness state colors for checked text, and
- change the label of the "Show drag handles" option (incl. translations), 
- and fix the keyboard controls that broke when migrating to draggable components.