### PR TITLE
VA-1201 Fix testing issues

### DIFF
--- a/css/dragquestion.css
+++ b/css/dragquestion.css
@@ -12,7 +12,8 @@
   --h5p-theme-font-size-s: 0.85em;
 }
 
-.h5p-dragquestion .h5p-question-plus-one-container, .h5p-dragquestion .h5p-question-minus-one-container {
+.h5p-dragquestion .h5p-question-plus-one-container,
+.h5p-dragquestion .h5p-question-minus-one-container {
   height: calc(1.25em * 0.638297872);
   position: absolute;
   right: -0.15em;
@@ -122,14 +123,6 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
 .h5p-dragquestion .h5p-draggable .h5p-image {
   height: 100%;
   width: 100%;
-}
-
-.h5p-dragquestion .h5p-draggable .h5p-question-minus-one-container {
-  height: calc(1.25em * 0.638297872);
-  right: 0;
-  position: absolute;
-  top: 0;
-  width: 1.25em;
 }
 
 .h5p-dragquestion .h5p-draggable p {

--- a/css/dragquestion.css
+++ b/css/dragquestion.css
@@ -81,9 +81,10 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
 .h5p-dragquestion .h5p-draggable {
   --padding: 0.3em;
 
-  position: absolute;
-  padding-block: var(--padding);
   line-height: 1.25em;
+  margin: 0; /* Overrides H5P.Components.Draggable margin */
+  padding-block: var(--padding);
+  position: absolute;
 }
 
 .h5p-dragquestion .h5p-draggable:not(.h5p-draggable--has-handle) {

--- a/src/drag-question.js
+++ b/src/drag-question.js
@@ -88,6 +88,7 @@ function C(options, contentId, contentData) {
 
   this.backgroundOpacity = (this.options.behaviour.backgroundOpacity === undefined || this.options.behaviour.backgroundOpacity.trim() === '') ? undefined : this.options.behaviour.backgroundOpacity;
 
+  // Additional dropzone that is added for keyboard users to be able to "unplace" a draggable
   self.$noDropZone = $('<div class="h5p-dq-no-dz" role="button" style="display:none;"><span class="h5p-hidden-read">' + self.options.noDropzone + '</span></div>');
 
   // Initialize controls for good a11y
@@ -1118,12 +1119,14 @@ var getControls = function (draggables, dropZones, noDropzone) {
     // Add special drop zone to reset
     controls.drop.addElement(noDropzone);
 
+    const draggableSize = selected.draggable.getSize();
+
     // Position at element position
     noDropzone.style.display = 'block';
     noDropzone.style.left = selected.draggable.x + '%';
     noDropzone.style.top = selected.draggable.y + '%';
-    noDropzone.style.width = selected.draggable.width + 'em';
-    noDropzone.style.height = selected.draggable.height + 'em';
+    noDropzone.style.width = `${draggableSize.width}px`;
+    noDropzone.style.height = `${draggableSize.height}px`;
 
     // Figure out which drop zones will accept this draggable
     var $first;

--- a/src/draggable.js
+++ b/src/draggable.js
@@ -562,4 +562,12 @@ export default class Draggable extends H5P.EventDispatcher {
     element.$.addClass('h5p-' + status).append($elementResult);
     element.$[0].setContentOpacity(this.backgroundOpacity);
   }
+
+  /**
+   * Get currnt size of draggable element.
+   * @returns {ClientRect | DOMRect} Current size of draggable element.
+   */
+  getSize() {
+    return this.element.$.get(0).getBoundingClientRect();
+  }
 }


### PR DESCRIPTION
When merged in, will
- remove old CSS for minus score explainer that lead to wrong indentation,
- remove the margin around draggables inherited from H5P.Components.Draggable that lead to an offset when placed, and
- Fix the size computation of the "no dropzone" dropzone.