### PR TITLE
fix: Use image title attribute for image draggable tooltip text (fixes https://github.com/h5p/h5p-drag-question/issues/232)

### DIFF
--- a/src/draggable.js
+++ b/src/draggable.js
@@ -139,6 +139,12 @@ export default class Draggable extends H5P.EventDispatcher {
     // Use placeholder image if none specified
     if (self.type.library.includes('H5P.Image')) {
       self.type.params.usePlaceholderImage = true;
+
+      if (self.type.params.title) {
+        H5P.Tooltip(instanceHolderDOM, {
+          text: self.type.params.title
+        });
+      }
     }
 
     H5P.newRunnable(self.type, contentId, H5P.jQuery(instanceHolderDOM));


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
fixes a bug: https://github.com/h5p/h5p-drag-question/issues/232

**What is the current behaviour?**
Image draggables don't relay the image's title attribute as they used to before NEUD was introduced.
Issue: https://github.com/h5p/h5p-drag-question/issues/232

**What is the new behaviour?**
H5P.Tooltip is used to relay the image's title attribute to the draggable.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
